### PR TITLE
Sorting and Filtering index queries

### DIFF
--- a/app/Busline.php
+++ b/app/Busline.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon as Carbon;
 use Illuminate\Support\Collection;
+use Spatie\QueryBuilder\QueryBuilder;
 
 /**
  * Busline model.
@@ -28,6 +29,17 @@ class Busline extends Model
         'created_at',
         'updated_at',
     ];
+
+    /**
+     * Returns QueryBuilder instance along with applied filters and sorts.
+     */
+    public static function filter(): QueryBuilder
+    {
+        return QueryBuilder::for(static::class)
+            ->allowedFilters(['number'])
+            ->allowedSorts('id', 'number')
+            ->allowedIncludes('paths', 'paths.courses');
+    }
 
     /**
      * Returns an instance of (one-to-many) relation with Busline class.

--- a/app/Course.php
+++ b/app/Course.php
@@ -7,6 +7,8 @@ namespace App;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon as Carbon;
+use Spatie\QueryBuilder\AllowedFilter;
+use Spatie\QueryBuilder\QueryBuilder;
 
 /**
  * Course model.
@@ -37,6 +39,17 @@ class Course extends Model
     protected $with = [
         'group',
     ];
+
+    /**
+     * Returns QueryBuilder instance along with applied filters and sorting.
+     */
+    public static function filter(): QueryBuilder
+    {
+        return QueryBuilder::for(static::class)
+            ->allowedFilters([AllowedFilter::exact('path_id'), AllowedFilter::exact('number')], 'start_time')
+            ->allowedSorts('id', 'path_id', 'group_id', 'start_time')
+            ->allowedIncludes('groups', 'paths');
+    }
 
     /**
      * Returns a 'start_time' attribute formatted to Hours:Minutes format.

--- a/app/Course.php
+++ b/app/Course.php
@@ -46,7 +46,7 @@ class Course extends Model
     public static function filter(): QueryBuilder
     {
         return QueryBuilder::for(static::class)
-            ->allowedFilters([AllowedFilter::exact('path_id'), AllowedFilter::exact('number')], 'start_time')
+            ->allowedFilters([AllowedFilter::exact('path_id'), AllowedFilter::exact('number'), 'start_time'])
             ->allowedSorts('id', 'path_id', 'group_id', 'start_time')
             ->allowedIncludes('groups', 'paths');
     }

--- a/app/Group.php
+++ b/app/Group.php
@@ -8,6 +8,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon as Carbon;
 use Illuminate\Support\Collection;
+use Spatie\QueryBuilder\AllowedFilter;
+use Spatie\QueryBuilder\QueryBuilder;
 
 /**
  * Group model.
@@ -27,6 +29,14 @@ class Group extends Model
         'created_at',
         'updated_at',
     ];
+
+    public static function filter(): QueryBuilder
+    {
+        return QueryBuilder::for(static::class)
+            ->allowedFilters([AllowedFilter::exact('busline_id')])
+            ->allowedSorts('id', 'busline_id')
+            ->allowedIncludes('courses', 'courses.paths');
+    }
 
     /**
      * Returns an instance of (one-to-many) relation with Busline class.

--- a/app/Http/Controllers/BuslineController.php
+++ b/app/Http/Controllers/BuslineController.php
@@ -17,7 +17,7 @@ class BuslineController extends Controller
      */
     public function index(): JsonResponse
     {
-        $buslines = Busline::all();
+        $buslines = Busline::filter()->get();
 
         return response()->json($buslines);
     }

--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -17,7 +17,7 @@ class CourseController extends Controller
      */
     public function index(): JsonResponse
     {
-        $courses = Course::all();
+        $courses = Course::filter()->get();
 
         return response()->json($courses);
     }

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -17,7 +17,7 @@ class GroupController extends Controller
      */
     public function index(): JsonResponse
     {
-        $groups = Group::all();
+        $groups = Group::filter()->get();
 
         return response()->json($groups);
     }

--- a/app/Http/Controllers/PathController.php
+++ b/app/Http/Controllers/PathController.php
@@ -17,7 +17,7 @@ class PathController extends Controller
      */
     public function index(): JsonResponse
     {
-        $paths = Path::all();
+        $paths = Path::filter()->get();
 
         return response()->json($paths);
     }

--- a/app/Http/Controllers/StationController.php
+++ b/app/Http/Controllers/StationController.php
@@ -17,7 +17,7 @@ class StationController extends Controller
      */
     public function index(): JsonResponse
     {
-        $stations = Station::all();
+        $stations = Station::filter()->get();
 
         return response()->json($stations, Response::HTTP_OK);
     }

--- a/app/Http/Controllers/TimetableController.php
+++ b/app/Http/Controllers/TimetableController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Services\TimetableService;
 use App\Timetable;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
@@ -27,11 +28,13 @@ class TimetableController extends Controller
     }
 
     /**
-     * Fetches current timetable version data.
+     * Fetches current timetable data.
      */
-    public function fetch(): JsonResponse
+    public function fetch(TimetableService $timetableService): JsonResponse
     {
-        return response()->json([], Response::HTTP_NOT_IMPLEMENTED);
+        $timetable = $timetableService->fetch();
+
+        return response()->json($timetable);
     }
 
     /**

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -18,7 +18,7 @@ class UserController extends Controller
      */
     public function index(): JsonResponse
     {
-        $users = User::all();
+        $users = User::filter()->get();
 
         return response()->json($users);
     }
@@ -38,7 +38,7 @@ class UserController extends Controller
      */
     public function show(User $user): JsonResponse
     {
-        return response()->json([$user]);
+        return response()->json($user);
     }
 
     /**

--- a/app/Path.php
+++ b/app/Path.php
@@ -45,7 +45,7 @@ class Path extends Model
         return QueryBuilder::for(static::class)
             ->allowedFilters([AllowedFilter::exact('busline_id')])
             ->allowedSorts('id', 'busline_id')
-            ->allowedIncludes('courses', 'buslines');
+            ->allowedIncludes('courses', 'busline', 'stations');
     }
 
     public function stations(): BelongsToMany

--- a/app/Path.php
+++ b/app/Path.php
@@ -10,6 +10,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Spatie\QueryBuilder\AllowedFilter;
+use Spatie\QueryBuilder\QueryBuilder;
 
 /**
  * Path model.
@@ -36,8 +38,16 @@ class Path extends Model
     ];
 
     /**
-     * Returns an instance of (many-to-many) relation with Station model.
+     * Returns QueryBuilder instance along with applied filters and sorts.
      */
+    public static function filter(): QueryBuilder
+    {
+        return QueryBuilder::for(static::class)
+            ->allowedFilters([AllowedFilter::exact('busline_id')])
+            ->allowedSorts('id', 'busline_id')
+            ->allowedIncludes('courses', 'buslines');
+    }
+
     public function stations(): BelongsToMany
     {
         return $this->belongsToMany(Station::class)

--- a/app/Services/StationPathService.php
+++ b/app/Services/StationPathService.php
@@ -39,6 +39,6 @@ class StationPathService
             $course->setAttribute('group', $course->group);
         }
 
-        return $timetable->toArray();
+        return $timetable->sortBy('departure_time')->toArray();
     }
 }

--- a/app/Services/StationPathService.php
+++ b/app/Services/StationPathService.php
@@ -22,7 +22,7 @@ class StationPathService
             $path->setAttribute('busline_number', $path->busline->number);
         }
 
-        return $paths->toArray();
+        return $paths->sortBy('busline_number')->values()->toArray();
     }
 
     /**
@@ -39,6 +39,6 @@ class StationPathService
             $course->setAttribute('group', $course->group);
         }
 
-        return $timetable->sortBy('departure_time')->toArray();
+        return $timetable->sortBy('departure_time')->values()->toArray();
     }
 }

--- a/app/Services/TimetableService.php
+++ b/app/Services/TimetableService.php
@@ -14,9 +14,7 @@ class TimetableService
     public function fetch(): array
     {
         $timetable = Path::with('stations')->with('courses')->get();
-
         foreach ($timetable as $path) {
-            //$path->setAttribute('courses', $path->courses());
             foreach ($path->stations as $station) {
                 $station->setAttribute('travel_time', $station->pivot->travel_time);
             }

--- a/app/Services/TimetableService.php
+++ b/app/Services/TimetableService.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Path;
+
+class TimetableService
+{
+    /**
+     * Shows all paths with attached stations with appended travel_time
+     */
+    public function fetch(): array
+    {
+        $timetable = Path::with('stations')->with('courses')->get();
+
+        foreach ($timetable as $path) {
+            //$path->setAttribute('courses', $path->courses());
+            foreach ($path->stations as $station) {
+                $station->setAttribute('travel_time', $station->pivot->travel_time);
+            }
+        }
+        return $timetable->toArray();
+    }
+}

--- a/app/Station.php
+++ b/app/Station.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Carbon as Carbon;
 use Illuminate\Support\Collection;
+use Spatie\QueryBuilder\QueryBuilder;
 
 /**
  * Station model.
@@ -39,6 +40,16 @@ class Station extends Model
         'created_at',
         'updated_at',
     ];
+
+    /**
+     * Returns QueryBuilder instance along with applied filters and sorts.
+     */
+    public static function filter(): QueryBuilder
+    {
+        return QueryBuilder::for(static::class)
+            ->allowedFilters(['name', 'position'])
+            ->allowedSorts('id', 'name', 'position');
+    }
 
     /**
      * Transforms input location data to Point object.

--- a/app/Station.php
+++ b/app/Station.php
@@ -48,7 +48,8 @@ class Station extends Model
     {
         return QueryBuilder::for(static::class)
             ->allowedFilters(['name', 'position'])
-            ->allowedSorts('id', 'name', 'position');
+            ->allowedSorts('id', 'name', 'position')
+            ->allowedIncludes('paths');
     }
 
     /**

--- a/app/User.php
+++ b/app/User.php
@@ -9,6 +9,7 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Carbon as Carbon;
 use Laravel\Sanctum\HasApiTokens;
 use Silber\Bouncer\Database\HasRolesAndAbilities;
+use Spatie\QueryBuilder\QueryBuilder;
 
 /**
  * User model.
@@ -39,4 +40,14 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    /**
+     * Returns QueryBuilder instance along with applied filters and sorts.
+     */
+    public static function filter(): QueryBuilder
+    {
+        return QueryBuilder::for(static::class)
+            ->allowedFilters(['email', 'name'])
+            ->allowedSorts('id', 'email', 'name');
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "laravel/framework": "^7.0",
         "laravel/sanctum": "^2.3",
         "laravel/tinker": "^2.0",
-        "silber/bouncer": "v1.0.0-rc.8"
+        "silber/bouncer": "v1.0.0-rc.8",
+        "spatie/laravel-query-builder": "^2.8"
     },
     "require-dev": {
         "facade/ignition": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5f61dd1b7039101db39a0193395804ca",
+    "content-hash": "b3da14deac69c3746129a87097e4eb98",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2223,6 +2223,64 @@
                 "roles"
             ],
             "time": "2020-03-31T15:14:45+00:00"
+        },
+        {
+            "name": "spatie/laravel-query-builder",
+            "version": "2.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-query-builder.git",
+                "reference": "2737b2298e8bfeb632a80013646943307bf31775"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-query-builder/zipball/2737b2298e8bfeb632a80013646943307bf31775",
+                "reference": "2737b2298e8bfeb632a80013646943307bf31775",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": "~5.6.34|~5.7.0|~5.8.0|^6.0|^7.0",
+                "illuminate/http": "~5.6.34|~5.7.0|~5.8.0|^6.0|^7.0",
+                "illuminate/support": "~5.6.34|~5.7.0|~5.8.0|^6.0|^7.0",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "orchestra/testbench": "~3.6.0|~3.7.0|~3.8.0|^4.0|^5.0",
+                "phpunit/phpunit": "^7.0|^8.0|^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\QueryBuilder\\QueryBuilderServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\QueryBuilder\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Vanderbist",
+                    "email": "alex@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily build Eloquent queries from API requests",
+            "homepage": "https://github.com/spatie/laravel-query-builder",
+            "keywords": [
+                "laravel-query-builder",
+                "spatie"
+            ],
+            "time": "2020-05-25T09:36:37+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/database/seeds/CourseSeeder.php
+++ b/database/seeds/CourseSeeder.php
@@ -12,7 +12,7 @@ class CourseSeeder extends Seeder
      */
     public function run(): void
     {
-        factory(Course::class, 500)->create()->each(function (Course $course): void {
+        factory(Course::class, 1000)->create()->each(function (Course $course): void {
             $course->save();
         });
     }

--- a/database/seeds/PathStationSeeder.php
+++ b/database/seeds/PathStationSeeder.php
@@ -17,12 +17,11 @@ class PathStationSeeder extends Seeder
 
         Path::all()->each(
             function (Path $path) use ($station_ids): void {
-                $first_station_id = $station_ids->random();
+                $random_station_ids = $station_ids->random(rand(3, 5));
                 $path->stations()->attach(
-                    $first_station_id,
+                    $random_station_ids->pop(),
                     ['travel_time' => 0]
                 );
-                $random_station_ids = $station_ids->random(rand(2, 4));
                 foreach ($random_station_ids as $station_id) {
                     $path->stations()->attach(
                         $station_id,

--- a/database/seeds/PathStationSeeder.php
+++ b/database/seeds/PathStationSeeder.php
@@ -15,14 +15,21 @@ class PathStationSeeder extends Seeder
     {
         $station_ids = Station::all()->pluck('id');
 
-        Path::all()->each(function (Path $path) use ($station_ids): void {
-            $random_station_ids = $station_ids->random(rand(6, 12));
-            foreach ($random_station_ids as $station_id) {
+        Path::all()->each(
+            function (Path $path) use ($station_ids): void {
+                $first_station_id = $station_ids->random();
                 $path->stations()->attach(
-                    $station_id,
-                    ['travel_time' => rand(0, 30)]
+                    $first_station_id,
+                    ['travel_time' => 0]
                 );
+                $random_station_ids = $station_ids->random(rand(2, 4));
+                foreach ($random_station_ids as $station_id) {
+                    $path->stations()->attach(
+                        $station_id,
+                        ['travel_time' => rand(1, 10)]
+                    );
+                }
             }
-        });
+        );
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -31,6 +31,7 @@ Route::apiResource('/courses', 'CourseController')->only(['index', 'show']);
 Route::get('/paths/{path}/stations', 'PathStationController@showAttachedStations');
 Route::get('/stations/{station}/paths', 'StationPathController@showAttachedPaths');
 Route::get('/stations/{station}/paths/{path}', 'StationPathController@showTimetable');
+Route::get('/timetable/fetch', 'TimetableController@fetch');
 
 Route::middleware('auth:sanctum')->group(function (): void {
 


### PR DESCRIPTION
1. Added an ability to filter, sort and access attached relationship data on most models.
This feature is using spatie/laravel-query-builder package.
Expected URI syntax should match package documentation:
https://docs.spatie.be/laravel-query-builder/v2/features
Parameters are accessed on standard index path and can be combined.

2. Timetable courses are now always sorted by departure_time attribute.

3. Adds new route for fetching timetable data and improves seeders accuracy for external services integration.